### PR TITLE
Add support for xenial

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,8 +27,9 @@ options:
       sources.list(5), or in the form ppa:<user>/<ppa-name> for adding
       Personal Package Archives, or a distribution component to enable.
     type: string
+    # TODO: make series dynamic, see: https://bugs.launchpad.net/layer-apt/+bug/1796993
     default: |
-      - deb https://packages.microsoft.com/repos/azure-cli/ bionic main
+      - deb https://packages.microsoft.com/repos/azure-cli/ xenial main
   install_keys:
     description: >
       List of signing keys for install_sources package sources, per

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,6 +9,7 @@ description: |
 maintainers: ['Cory Johns <johnsca@gmail.com>']
 series:
   - bionic
+  - xenial
 tags: ['azure', 'native', 'integration']
 provides:
   clients:


### PR DESCRIPTION
Tested on both xenial and bionic.  The xenial package source works fine on bionic, but not the other way around.  You could always manually change the config if needed, until the automatic series support is available.