### PR TITLE
Parse credentials config value

### DIFF
--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -40,6 +40,10 @@ def log(msg, *args):
     hookenv.log(msg.format(*args), hookenv.INFO)
 
 
+def log_debug(msg, *args):
+    hookenv.log(msg.format(*args), hookenv.DEBUG)
+
+
 def log_err(msg, *args):
     hookenv.log(msg.format(*args), hookenv.ERROR)
 
@@ -73,10 +77,12 @@ def get_credentials():
     if config['credentials']:
         try:
             creds_data = b64decode(config['credentials']).decode('utf8')
-            login_cli(creds_data)
+            login_cli(json.loads(creds_data))
             return True
-        except Exception:
-            status.blocked('invalid value for credentials config')
+        except Exception as ex:
+            msg = 'invalid value for credentials config'
+            log_debug('{}: {}', msg, ex)
+            status.blocked(msg)
             return False
 
     # no creds provided


### PR DESCRIPTION
When juju trust is not available (e.g. manual provider) the credentials
config option holds a string that represents a json dictionary.

This patch parses the value passed by the user to transform it into a
dictionary.

Co-authored-by: Ivan Hitos <ivan.hitos@canonical.com>