### PR TITLE
Handle different "not found" error message

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,4 +1,4 @@
-repo: 'https://github.com/juju-solutions/layer-azure'
+repo: 'https://github.com/juju-solutions/charm-azure-integrator'
 includes:
   - 'layer:basic'
   - 'layer:status'

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -270,6 +270,8 @@ class AzureError(Exception):
             return AlreadyExistsAzureError(message)
         if 'Please provide' in message and 'an existing' in message:
             return DoesNotExistAzureError(message)
+        if 'No definition was found' in message:
+            return DoesNotExistAzureError(message)
         return AzureError(message)
 
 
@@ -377,7 +379,7 @@ def _get_role(role_name):
         log('Ensuring role {}', role_fullname)
         _azure('role', 'definition', 'create',
                '--role-definition', json.dumps(role_data))
-    except AlreadyExistsAzureError as e:
+    except AlreadyExistsAzureError:
         pass
     known_roles[role_name] = role_fullname
     kv().set('charm.azure.roles', known_roles)


### PR DESCRIPTION
It seems that in some unusual cases, Azure can return a different error message than what we're expecting for the "not found" case, causing the charm to fail.

Fixes [lp:1823111](https://bugs.launchpad.net/charm-azure-integrator/+bug/1823111)