### PR TITLE
Add logic path to disable Managed Identity

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,26 +11,6 @@ options:
       This config must be set at deployment and cannot be changed later.
     type: string
     default: ''
-  aadClient:
-    description:
-      The Service Principal client ID to use for this. Disables Managed Identity.
-    default: ''
-    type: string
-  aadClientSecret:
-    description:
-      The client secret to use for access to the azure platform.
-    default: ''
-    type: string
-  subscriptionId:
-    description:
-      The subscription the cluster is deployed under.
-    default: ''
-    type: string
-  tenantId:
-    description:
-      The tenant the cluster is deployed under.
-    default: ''
-    type: string
   subnetName:
     description:
       Vnet's subnet to be used by azure cloud-integration.
@@ -46,8 +26,9 @@ options:
   credentials:
     description: |
       The base64-encoded JSON credentials data, which must include the 'application-id',
-      'application-password', and the 'subscription-id'.  These values can be retrieved
-      from Juju using the 'credentials' command and extracting the value of the 'details'
+      'application-password', and the 'subscription-id'. Optionally can include managed-identity (default true) 
+      and tenant-id (default '').
+      These values can be retrieved from Juju using the 'credentials' command and extracting the value of the 'details'
       key for the appropriate credential. For example, using 'jq', replace '<credential-name>'
       in the following:
 

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,26 @@ options:
       This config must be set at deployment and cannot be changed later.
     type: string
     default: ''
+  aadClient:
+    description:
+      The Service Principal client ID to use for this. Disables Managed Identity.
+    default: ''
+    type: string
+  aadClientSecret:
+    description:
+      The client secret to use for access to the azure platform.
+    default: ''
+    type: string
+  subscriptionId:
+    description:
+      The subscription the cluster is deployed under.
+    default: ''
+    type: string
+  tenantId:
+    description:
+      The tenant the cluster is deployed under.
+    default: ''
+    type: string
   subnetName:
     description:
       Vnet's subnet to be used by azure cloud-integration.

--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,12 @@ options:
       This config must be set at deployment and cannot be changed later.
     type: string
     default: 'juju-internal-nsg'
+  vnetSecurityGroupResourceGroup:
+    description:
+      Default network sec group (NSG) to be used by azure cloud integration.
+      This config must be set at deployment and cannot be changed later.
+    type: string
+    default: ''
   credentials:
     description: |
       The base64-encoded JSON credentials data, which must include the 'application-id',

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -92,7 +92,8 @@ def get_credentials():
     except subprocess.CalledProcessError as e:
         if "permission denied" not in e.stderr.decode("utf8"):
             raise
-        no_creds_msg = 'missing credentials access; grant with: juju trust'
+        no_creds_msg = "missing credentials access; grant with: juju trust"
+
     # try credentials config
     if config["credentials"]:
         try:
@@ -175,7 +176,7 @@ def send_additional_metadata(request):
     """
     run_config = hookenv.config() or {}
     res_grp = _azure("group", "show", "--name", request.resource_group)
-    credentials = kv().get('charm.azure.creds_data', {}) 
+    credentials = kv().get("charm.azure.creds_data", {}) 
     # hard-code most of these because with Juju, they're always the same
     # and the queries required to look them up are a PITA
     request.send_additional_metadata(

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -99,7 +99,7 @@ def get_credentials():
         try:
             creds_data = b64decode(config["credentials"]).decode("utf8")
             loaded_creds = json.loads(creds_data)
-            loaded_creds["managed-identity"] = loaded_creds.get("managed-identity") if loaded_creds.get("managed-identity") else True
+            loaded_creds["managed-identity"] = loaded_creds.get("managed-identity") if loaded_creds.get("managed-identity", "") != "" else True
             kv().set("charm.azure.creds_data", loaded_creds)
             login_cli(loaded_creds)
             return True
@@ -193,6 +193,9 @@ def send_additional_metadata(request):
         security_group_name=run_config.get("vnetSecurityGroup")
         if run_config.get("vnetSecurityGroup")
         else "juju-internal-nsg",
+        security_group_resource_group=run_config.get("vnetSecurityGroupResourceGroup")
+        if run_config.get("vnetSecurityGroupResourceGroup")
+        else "",
         use_managed_identity=credentials.get("managed-identity")
         if credentials.get("managed-identity", "") != "" 
         else True,

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -73,7 +73,7 @@ def get_credentials():
 
     Prefers the config so that it can be overridden.
     """
-    no_creds_msg = "missing credentials; set credentials config"
+    msg = "missing credentials; set credentials config"
     config = hookenv.config()
     credentials = {}
     # try to use Juju's trust feature
@@ -105,11 +105,14 @@ def get_credentials():
         except Exception as ex:
             msg = "invalid value for credentials config"
             log_debug("{}: {}", msg, ex)
-            status.blocked(msg)
+            credentials = {}
+
+    if credentials == {}:
+        status.blocked(msg)
+        return credentials
 
     loaded_creds.setdefault("managed-identity", True)
-    # no creds provided
-    status.blocked(no_creds_msg)
+
     return credentials
 
 def login_cli(creds_data):

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -84,7 +84,7 @@ def get_credentials():
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        creds = yaml.load(result.stdout.decode("utf8"))
+        creds = yaml.safe_load(result.stdout.decode("utf8"))
         creds_data = creds["credential"]["attributes"]
         login_cli(creds_data)
         credentials = creds_data
@@ -111,7 +111,7 @@ def get_credentials():
         status.blocked(msg)
         return credentials
 
-    loaded_creds.setdefault("managed-identity", True)
+    credentials.setdefault("managed-identity", True)
 
     return credentials
 
@@ -195,9 +195,7 @@ def send_additional_metadata(request):
         security_group_name=run_config.get("vnetSecurityGroup")
         if run_config.get("vnetSecurityGroup")
         else "juju-internal-nsg",
-        security_group_resource_group=run_config.get("vnetSecurityGroupResourceGroup")
-        if run_config.get("vnetSecurityGroupResourceGroup")
-        else "",
+        security_group_resource_group=run_config["vnetSecurityGroupResourceGroup"],
         use_managed_identity=credentials["managed-identity"],
         aad_client=credentials["application-id"],
         aad_secret=credentials["application-password"],

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -175,6 +175,7 @@ def send_additional_metadata(request):
     """
     run_config = hookenv.config() or {}
     res_grp = _azure("group", "show", "--name", request.resource_group)
+    credentials = kv().get('charm.azure.creds_data', {}) 
     # hard-code most of these because with Juju, they're always the same
     # and the queries required to look them up are a PITA
     request.send_additional_metadata(
@@ -191,18 +192,18 @@ def send_additional_metadata(request):
         security_group_name=run_config.get("vnetSecurityGroup")
         if run_config.get("vnetSecurityGroup")
         else "juju-internal-nsg",
-        use_managed_identity=False 
-        if run_config.get('aadClient') 
+        use_managed_identity=credentials.get("managed-identity")
+        if credentials.get("managed-identity", "") != "" 
         else True,
-        aad_client=run_config.get('aadClient')
-        if run_config.get('aadClient')
-        else None,
-        aad_secret=run_config.get('aadClientSecret')
-        if run_config.get('aadClientSecret') 
-        else None,
-        tenant_id=run_config.get('tenantId') 
-        if run_config.get('tenantId') 
-        else None
+        aad_client=credentials.get("application-id") 
+        if credentials.get("application-id") 
+        else "",
+        aad_secret=credentials.get("application-password") 
+        if credentials.get("application-password") 
+        else "",
+        tenant_id=credentials.get("tenant-id") 
+        if credentials.get("tenant-id") 
+        else ""
     )
 
 

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -99,7 +99,7 @@ def get_credentials():
         try:
             creds_data = b64decode(config["credentials"]).decode("utf8")
             loaded_creds = json.loads(creds_data)
-            loaded_creds["managed-identity"] = loaded_creds.get("managed-identity") if loaded_creds.get("managed-identity", "") != "" else True
+            loaded_creds["managed-identity"] = loaded_creds.get("managed-identity") if loaded_creds.get("managed-identity") else True
             kv().set("charm.azure.creds_data", loaded_creds)
             login_cli(loaded_creds)
             return True

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -92,8 +92,15 @@ def get_credentials():
     except subprocess.CalledProcessError as e:
         if "permission denied" not in e.stderr.decode("utf8"):
             raise
-        no_creds_msg = "missing credentials access; grant with: juju trust"
-
+        no_creds_msg = 'missing credentials access; grant with: juju trust'
+    # We have the aadClient credentials. Do not used managed identity
+    if config['aadClient']:
+        login_cli({
+            'application-id': config['aadClient'],
+            'application-password': config['aadClientSecret'],
+            'subscription-id': config['subscriptionId']
+        })
+        return True
     # try credentials config
     if config["credentials"]:
         try:
@@ -189,6 +196,18 @@ def send_additional_metadata(request):
         security_group_name=run_config.get("vnetSecurityGroup")
         if run_config.get("vnetSecurityGroup")
         else "juju-internal-nsg",
+        use_managed_identity=False 
+        if run_config.get('aadClient') 
+        else True,
+        aad_client=run_config.get('aadClient')
+        if run_config.get('aadClient')
+        else None,
+        aad_secret=run_config.get('aadClientSecret')
+        if run_config.get('aadClientSecret') 
+        else None,
+        tenant_id=run_config.get('tenantId') 
+        if run_config.get('tenantId') 
+        else None
     )
 
 

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -93,7 +93,7 @@ def get_credentials():
     except subprocess.CalledProcessError as e:
         if "permission denied" not in e.stderr.decode("utf8"):
             raise
-        no_creds_msg = "missing credentials access; grant with: juju trust"
+        msg = "missing credentials access; grant with: juju trust"
 
     # try credentials config
     if config["credentials"]:

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -115,6 +115,7 @@ def get_credentials():
 
     return credentials
 
+
 def login_cli(creds_data):
     """
     Use the credentials to authenticate the Azure CLI.
@@ -197,18 +198,10 @@ def send_additional_metadata(request):
         security_group_resource_group=run_config.get("vnetSecurityGroupResourceGroup")
         if run_config.get("vnetSecurityGroupResourceGroup")
         else "",
-        use_managed_identity=credentials.get("managed-identity")
-        if credentials.get("managed-identity", "") != "" 
-        else True,
-        aad_client=credentials.get("application-id") 
-        if credentials.get("application-id") 
-        else "",
-        aad_secret=credentials.get("application-password") 
-        if credentials.get("application-password") 
-        else "",
-        tenant_id=credentials.get("tenant-id") 
-        if credentials.get("tenant-id") 
-        else ""
+        use_managed_identity=credentials["managed-identity"],
+        aad_client=credentials["application-id"],
+        aad_secret=credentials["application-password"],
+        tenant_id=credentials["tenant-id"],
     )
 
 
@@ -326,7 +319,6 @@ def create_loadbalancer(request):
         "Standard",
         "--tags",
         model_tag + ",request-name=" + request.name,
-
     ]
 
     if request.public:
@@ -424,7 +416,7 @@ def create_loadbalancer(request):
             "--resource-group",
             resource_group,
             "--query",
-            "[*].priority"
+            "[*].priority",
         )
         nsg_priorities = set(nsg_priorities)
         # juju uses priority 100+ for base rules, 200+ for `juju expose` rules
@@ -464,7 +456,7 @@ def create_loadbalancer(request):
                             "--access",
                             "allow",
                             "--priority",
-                            priority
+                            priority,
                         )
                         break
                     except SecurityRuleConflictAzureError:
@@ -484,7 +476,7 @@ def create_loadbalancer(request):
             "--resource-group",
             resource_group,
             "--query",
-            "ipAddress"
+            "ipAddress",
         )
     else:
         ip = _azure(
@@ -552,7 +544,7 @@ def remove_loadbalancer(request):
         "--nsg-name",
         config["vnetSecurityGroup"],
         "--query",
-        "[*].name"
+        "[*].name",
     )
     for nsg_rule in nsg_rules:
         if not nsg_rule.startswith("{}-".format(lb_name)):
@@ -568,7 +560,7 @@ def remove_loadbalancer(request):
                 "--nsg-name",
                 config["vnetSecurityGroup"],
                 "--name",
-                nsg_rule
+                nsg_rule,
             )
         except DoesNotExistAzureError:
             pass
@@ -723,6 +715,7 @@ class SecurityRuleConflictAzureError(AzureError):
     """
     Meta-error subclass of AzureError representing a security rule conflict.
     """
+
     pass
 
 

--- a/reactive/azure.py
+++ b/reactive/azure.py
@@ -29,9 +29,9 @@ def get_creds():
 @when_not("charm.azure.initial-role-update")
 def update_roles_on_install():
     layer.status.maintenance("loading roles")
-    if kv().get('charm.azure.creds_data') and not kv().get('charm.azure.creds_data').get('managed-identity'):
-        layer.status.active('ready')
-        set_flag('charm.azure.initial-role-update')
+    if kv().get("charm.azure.creds_data") and not kv().get("charm.azure.creds_data").get("managed-identity"):
+        layer.status.active("ready")
+        set_flag("charm.azure.initial-role-update")
         return
     layer.azure.update_roles()
     set_flag("charm.azure.initial-role-update")
@@ -56,8 +56,8 @@ def no_requests():
     "endpoint.clients.requests-pending",
 )
 def handle_requests():
-    azure = endpoint_from_name('clients')
-    creds_data = kv().get('charm.azure.creds_data')
+    azure = endpoint_from_name("clients")
+    creds_data = kv().get("charm.azure.creds_data")
     try:
         for request in azure.requests:
             layer.status.maintenance(
@@ -68,7 +68,7 @@ def handle_requests():
             layer.azure.ensure_msi(request)
             layer.azure.send_additional_metadata(request)
 
-            if creds_data is not None and not creds_data.get('managed-identity'):
+            if creds_data is not None and not creds_data.get("managed-identity"):
                 # We don't need to perform operations on the VMs. The Service Principal is taking care of ops.
                 azure.mark_completed()
                 continue
@@ -143,8 +143,8 @@ def cleanup():
 
 @hook("upgrade-charm")
 def update_roles():
-    creds_data = kv().get('charm.azure.creds_data')
-    if creds_data is not None and not creds_data.get('managed-identity'):
+    creds_data = kv().get("charm.azure.creds_data")
+    if creds_data is not None and not creds_data.get("managed-identity"):
         return
     layer.azure.update_roles()
 

--- a/reactive/azure.py
+++ b/reactive/azure.py
@@ -1,4 +1,3 @@
-import json
 from traceback import format_exc
 
 from charms.reactive import (
@@ -11,7 +10,6 @@ from charms.reactive import (
     hook,
 )
 from charms.reactive.relations import endpoint_from_name
-from charmhelpers.core import hookenv
 from charmhelpers.core.unitdata import kv
 from charms import layer
 

--- a/reactive/azure.py
+++ b/reactive/azure.py
@@ -11,9 +11,9 @@ from charms.reactive import (
     is_flag_set
 )
 from charms.reactive.relations import endpoint_from_name
-from charmhelpers.core.unitdata import kv
 from charms import layer
 from charms.layer.azure import get_credentials
+
 
 @when_any("config.changed.credentials")
 def update_creds():
@@ -34,6 +34,7 @@ def update_roles_on_install():
         layer.azure.update_roles()
     set_flag("charm.azure.initial-role-update")
     layer.status.active("Ready")
+
 
 @when_all(
     "apt.installed.azure-cli",
@@ -64,7 +65,8 @@ def handle_requests():
             )
             layer.azure.send_additional_metadata(request)
             if not creds_data["managed-identity"]:
-                # We don't need to perform operations on the VMs. The Service Principal is taking care of ops.
+                # We don't need to perform operations on the VMs.
+                # The Service Principal is taking care of ops.
                 azure.mark_completed()
                 continue
             layer.azure.ensure_msi(request)
@@ -140,7 +142,7 @@ def cleanup():
 def update_roles():
     if not is_flag_set("charm.azure.creds.set"):
         return
-    if not get_credentials()["managed-identity"]: 
+    if not get_credentials()["managed-identity"]:
         return
     layer.azure.update_roles()
 

--- a/reactive/azure.py
+++ b/reactive/azure.py
@@ -54,7 +54,7 @@ def no_requests():
 )
 def handle_requests():
     azure = endpoint_from_name("clients")
-    creds_data = kv().get("charm.azure.creds_data")
+    creds_data = get_credentials()
     try:
         for request in azure.requests:
             layer.status.maintenance(
@@ -63,7 +63,7 @@ def handle_requests():
                 )
             )
             layer.azure.send_additional_metadata(request)
-            if not get_credentials()["managed-identity"]:
+            if not creds_data["managed-identity"]:
                 # We don't need to perform operations on the VMs. The Service Principal is taking care of ops.
                 azure.mark_completed()
                 continue

--- a/reactive/azure.py
+++ b/reactive/azure.py
@@ -140,7 +140,7 @@ def cleanup():
 def update_roles():
     if not is_flag_set("charm.azure.creds.set"):
         return
-    if get_credentials()["managed-identity"]: 
+    if not get_credentials()["managed-identity"]: 
         return
     layer.azure.update_roles()
 

--- a/reactive/azure.py
+++ b/reactive/azure.py
@@ -67,7 +67,6 @@ def handle_requests():
             if not creds_data["managed-identity"]:
                 # We don't need to perform operations on the VMs.
                 # The Service Principal is taking care of ops.
-                azure.mark_completed()
                 continue
             layer.azure.ensure_msi(request)
             if request.instance_tags:

--- a/tests/unit/test_azure_integrator.py
+++ b/tests/unit/test_azure_integrator.py
@@ -1,9 +1,137 @@
-from charms import layer
+import json
+from base64 import b64encode
+from unittest.mock import Mock, patch
 
-from reactive.azure import pre_series_upgrade
+from charmhelpers.core import hookenv
+from charms.reactive import set_flag
+
+from charms import layer
+from reactive import azure as reactive_azure
 
 
 def test_series_upgrade():
+    layer.status.blocked.reset_mock()
     assert layer.status.blocked.call_count == 0
-    pre_series_upgrade()
+    reactive_azure.pre_series_upgrade()
     assert layer.status.blocked.call_count == 1
+
+
+@patch.object(reactive_azure, "get_credentials")
+@patch.object(layer, "azure")
+def test_update_roles_on_install(lib_azure, get_credentials):
+    get_credentials.return_value = {"managed-identity": False}
+    reactive_azure.update_roles_on_install()
+    assert not lib_azure.update_roles.called
+
+    get_credentials.return_value = {"managed-identity": True}
+    reactive_azure.update_roles_on_install()
+    assert lib_azure.update_roles.called
+
+
+@patch.object(reactive_azure, "get_credentials")
+@patch.object(layer, "azure")
+def test_update_roles_on_upgrade(lib_azure, get_credentials):
+    reactive_azure.update_roles()
+    assert not get_credentials.called
+    assert not lib_azure.update_roles.called
+
+    set_flag("charm.azure.creds.set")
+    get_credentials.return_value = {"managed-identity": False}
+    reactive_azure.update_roles()
+    assert get_credentials.called
+    assert not lib_azure.update_roles.called
+
+    get_credentials.return_value = {"managed-identity": True}
+    reactive_azure.update_roles()
+    assert lib_azure.update_roles.called
+
+
+@patch.object(reactive_azure, "get_credentials")
+@patch.object(layer, "azure")
+def test_handle_requests(lib_azure, get_credentials):
+    get_credentials.return_value = {"managed-identity": False}
+    ep = reactive_azure.endpoint_from_name.return_value
+    ep.requests = [Mock()]
+    reactive_azure.handle_requests()
+    assert lib_azure.send_additional_metadata.called
+    assert not lib_azure.ensure_msi.called
+    assert ep.mark_completed.call_count == 1
+
+    ep.mark_completed.reset_mock()
+    get_credentials.return_value = {"managed-identity": True}
+    reactive_azure.handle_requests()
+    assert lib_azure.ensure_msi.called
+    assert ep.mark_completed.call_count == 1
+
+
+@patch.object(layer.azure, "get_credentials")
+@patch.object(layer.azure, "_azure")
+def test_send_additional_metadata(_azure, get_credentials):
+    hookenv.config.return_value = {
+        "vnetSecurityGroupResourceGroup": "vnet-sg",
+    }
+    get_credentials.return_value = {
+        "managed-identity": "mi",
+        "application-id": "aid",
+        "application-password": "apwd",
+        "tenant-id": "tid",
+    }
+    _azure.return_value = {"location": "loc"}
+    request = Mock(resource_group="rg")
+    layer.azure.send_additional_metadata(request)
+    request.send_additional_metadata.assert_called_with(
+        resource_group_location="loc",
+        vnet_name="juju-internal-network",
+        vnet_resource_group="rg",
+        subnet_name="juju-internal-subnet",
+        security_group_name="juju-internal-nsg",
+        security_group_resource_group="vnet-sg",
+        use_managed_identity="mi",
+        aad_client="aid",
+        aad_secret="apwd",
+        tenant_id="tid",
+    )
+
+
+@patch.object(layer.azure, "login_cli")
+@patch("subprocess.run")
+def test_get_credentials(run, login_cli):
+    layer.status.blocked.reset_mock()
+    run.side_effect = FileNotFoundError
+    hookenv.config.return_value = {"credentials": ""}
+    assert layer.azure.get_credentials() == {}
+    assert layer.status.blocked.called
+
+    layer.status.blocked.reset_mock()
+    run.side_effect = None
+    run().stdout = "{'credential': {'attributes': {'foo': 'bar'}}}".encode("utf8")
+    assert layer.azure.get_credentials() == {
+        "foo": "bar",
+        "managed-identity": True,
+    }
+    assert not layer.status.blocked.called
+
+    layer.status.blocked.reset_mock()
+    hookenv.config.return_value = {"credentials": "foo"}
+    assert layer.azure.get_credentials() == {}
+    assert layer.status.blocked.called
+    assert layer.status.blocked.call_args[0] == (
+        "invalid value for credentials config",
+    )
+
+    layer.status.blocked.reset_mock()
+    hookenv.config.return_value = {
+        "credentials": b64encode(
+            json.dumps(
+                {
+                    "foo": "qux",
+                    "managed-identity": False,
+                }
+            ).encode("utf8")
+        )
+    }
+    assert layer.azure.get_credentials() == {
+        "foo": "qux",
+        "managed-identity": False,
+    }
+    assert not layer.status.blocked.called

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
     pytest
     ipdb
     charms.unit_test
+    pyyaml
 commands = pytest -svv --tb native {posargs} tests/unit
 
 [testenv:integration]


### PR DESCRIPTION
Managed Identity requires a "Owner" service principal to create and manage role assignments for the managed identities (VMs). This presents the problem of creating a service principal with such permissions.

Creating such application credentials present a security risk as if a malicious user were to gain access they could create accounts/create roles/assign roles/destroy the subscription (Virtual Datacentre) on azure.

This change mitigates this issue by enabling Charmed Kubernetes to use the service principal directly, instead of requiring a service principal with board permissions to assign roles.

Related [Interface change](https://github.com/juju-solutions/interface-azure-integration/pull/6)
Related [Layer kubernetes common change](https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/18)
Fixes [LP#1928906](https://bugs.launchpad.net/charm-azure-integrator/+bug/1928906)

- [x] Test disable managed identity path
- [x]  Test "credentials" file path
- [x]  Test juju grant path