### PR TITLE
fix `az login` argument parsing

### DIFF
--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -134,12 +134,9 @@ def login_cli(creds_data):
         _azure(
             "login",
             "--service-principal",
-            "-u",
-            app_id,
-            "-p",
-            app_pass,
-            "-t",
-            tenant_id,
+            f"-u={app_id}",
+            f"-p={app_pass}",
+            f"-t={tenant_id}",
         )
         # cache the subscription ID for use in roles
         kv().set("charm.azure.sub-id", sub_id)


### PR DESCRIPTION
Hi,

When configuring the azure integrator the secrets are passed with the form -a value, this presents a problem with configuring the credentials.

A secret beginning with `-` is parsed as an arguement, e.g. -p -gG£^T"$FV"TST". This raises the following error:

-> tenant_id,
(Pdb) n

ncharms.layer.azure.AzureError: ERROR: argument --password/-p: expected one argument

TRY THIS:
az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
Log in with a service principal using client secret. Use -p=secret if the first character of the password is '-'.

az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
Log in with a service principal using client certificate.

az login -u johndoe@contoso.com -p VerySecret
Log in with user name and password. This doesn't work with Microsoft accounts or accounts that have two-factor authentication enabled. Use -p=secret if the first character of the password is '-'.

https://aka.ms/cli_ref

Workaround:

Regenerate secret

[LP#1933994](https://bugs.launchpad.net/charm-azure-integrator/+bug/1933994)