### PR TITLE
Add support for subnetID option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,13 @@ options:
       This config must be set at deployment and cannot be changed later.
     type: string
     default: ''
+  subnetID:
+    description:
+      It is recommended to specify the ID of the subnet instead of its name for load balancer creation.
+      That is specially important in more complex scenarios, e.g. using subnets and vnets present on a
+      resource group different from where the load balancer should exist or its backend VMs are.
+    type: string
+    default: ""
   subnetName:
     description:
       Vnet's subnet to be used by azure cloud-integration.

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -321,12 +321,23 @@ def create_loadbalancer(request):
             "--public-ip-address",
             lb_public_ip_name,
         ]
-    else:
+    elif request.ingress_address:
+        lb_create_args += [
+            "--private-ip-address",
+            request.ingress_address
+        ]
+
+    if len(config["subnetID"]) == 0:
         lb_create_args += [
             "--vnet-name",
             config["vnetName"],
             "--subnet",
             config["subnetName"],
+        ]
+    else:
+        lb_create_args += [
+            "--subnet",
+            config["subnetID"],
         ]
 
     _azure("network", *lb_create_args)

--- a/reactive/azure.py
+++ b/reactive/azure.py
@@ -100,6 +100,11 @@ def handle_requests():
         )
 
 
+@when_all(
+    "apt.installed.azure-cli",
+    "charm.azure.creds.set",
+    "charm.azure.initial-role-update",
+)
 @when_any("endpoint.lb-consumers.requests_changed")
 def manage_lbs():
     lb_consumers = endpoint_from_name("lb-consumers")


### PR DESCRIPTION
This change implements the features described on LP#1939248.
LBProviders can now issue a request with fixed ingress IP for
private LBs (point 1) and subnetID can be specified instead
of vnetName + subnetName. SubnetID covers the case where
subnets can be provided by vnets on different RGs (point 2).

Add a when_all check for manage_lbs() (LP#1937300).