### PR TITLE
Fetch subscription ID along with VM metadata

### DIFF
--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -178,7 +178,6 @@ def send_additional_metadata(request):
     if hasattr(request, 'subscription_id'):
         res_grp_args += ["--subscription", request.subscription_id]
     res_grp = _azure(*res_grp_args)
-    
     credentials = get_credentials()
     # hard-code most of these because with Juju, they're always the same
     # and the queries required to look them up are a PITA

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -174,14 +174,12 @@ def send_additional_metadata(request):
     available from the metadata server.
     """
     run_config = hookenv.config() or {}
-    res_grp = _azure(
-            "group",
-            "show",
-            "--subscription",
-            request.subscription_id,
-            "--name",
-            request.resource_group
-        )
+    res_grp_args = ["group", "show", "--name", request.resource_group]
+    if hasattr(request, 'subscription_id'):
+        for pos, arg in enumerate(["--subscription", request.subscription_id]):
+            res_grp_args.insert(pos + 2, arg)
+
+    res_grp = _azure(*res_grp_args)
     credentials = get_credentials()
     # hard-code most of these because with Juju, they're always the same
     # and the queries required to look them up are a PITA

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -174,7 +174,14 @@ def send_additional_metadata(request):
     available from the metadata server.
     """
     run_config = hookenv.config() or {}
-    res_grp = _azure("group", "show", "--subscription", request.subscription_id, "--name", request.resource_group)
+    res_grp = _azure(
+            "group",
+            "show",
+            "--subscription",
+            request.subscription_id,
+            "--name",
+            request.resource_group
+        )
     credentials = get_credentials()
     # hard-code most of these because with Juju, they're always the same
     # and the queries required to look them up are a PITA

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -174,7 +174,7 @@ def send_additional_metadata(request):
     available from the metadata server.
     """
     run_config = hookenv.config() or {}
-    res_grp = _azure("group", "show", "--name", request.resource_group)
+    res_grp = _azure("group", "show", "--subscription", request.subscription_id, "--name", request.resource_group)
     credentials = get_credentials()
     # hard-code most of these because with Juju, they're always the same
     # and the queries required to look them up are a PITA

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -176,10 +176,9 @@ def send_additional_metadata(request):
     run_config = hookenv.config() or {}
     res_grp_args = ["group", "show", "--name", request.resource_group]
     if hasattr(request, 'subscription_id'):
-        for pos, arg in enumerate(["--subscription", request.subscription_id]):
-            res_grp_args.insert(pos + 2, arg)
-
+        res_grp_args += ["--subscription", request.subscription_id]
     res_grp = _azure(*res_grp_args)
+    
     credentials = get_credentials()
     # hard-code most of these because with Juju, they're always the same
     # and the queries required to look them up are a PITA


### PR DESCRIPTION
If an account supplied to the Azure Integrator has more than one subscription associated with it, by default it will login to both subscriptions on the Azure CLI. This presents a problem for Subscription Selection.

Currently when fetching VM metadata Subscription IDs are not used. This results in an error when fetching the resource group inside of the azure-integrator.

This change is to collect the subscription ID and use it in the fetching of Azure Resource Groups

Fixes [LP#1946089](https://bugs.launchpad.net/charm-azure-integrator/+bug/1946089)
[Related PR](https://github.com/juju-solutions/interface-azure-integration/pull/7)

