### PR TITLE
Fix config and credential changes not being sent to Kubernetes charms

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,2 @@
+refresh-credentials:
+  description: Force the charm to recheck cloud credentials

--- a/actions/refresh-credentials
+++ b/actions/refresh-credentials
@@ -1,0 +1,8 @@
+#!/usr/local/sbin/charm-env python3
+
+import charms.layer
+import charms.reactive
+
+charms.reactive.clear_flag('charm.azure.creds.set')
+charms.layer.import_layer_libs()
+charms.reactive.main()

--- a/config.yaml
+++ b/config.yaml
@@ -2,31 +2,26 @@ options:
   vnetName:
     description:
       VnetName to be passed via cloud-integration.
-      This config must be set at deployment and cannot be changed later.
     type: string
     default: 'juju-internal-network'
   vnetResourceGroup:
     description:
       Vnet's resource group to be passed via cloud-integration.
-      This config must be set at deployment and cannot be changed later.
     type: string
     default: ''
   subnetName:
     description:
       Vnet's subnet to be used by azure cloud-integration.
-      This config must be set at deployment and cannot be changed later.
     type: string
     default: 'juju-internal-subnet'
   vnetSecurityGroup:
     description:
       Default network sec group (NSG) to be used by azure cloud integration.
-      This config must be set at deployment and cannot be changed later.
     type: string
     default: 'juju-internal-nsg'
   vnetSecurityGroupResourceGroup:
     description:
       Default network sec group (NSG) to be used by azure cloud integration.
-      This config must be set at deployment and cannot be changed later.
     type: string
     default: ''
   credentials:


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/bugs/1915557

Depends on https://github.com/juju-solutions/interface-azure-integration/pull/8

When cloud configuration or credentials change, resend cloud data to units whose requests have already been processed.

There's a bit of nasty stuff in here to handle the variety of cases in which cloud credentials can change. From a high level, here's what you need to know:

1. If the charm config changes in any way (user runs `juju config azure-integrator <foo>`), then the charm's `config-changed` hook will run, with the `config.changed` flag set, and that will cause `handle_requests` to run and refresh requests.
2. If the charm is not configured with credentials directly, then it pulls credentials from Juju instead. When the user updates those credentials with a command like `juju update-credential`, Juju will not inform the charm that those credentials have changed. So we monitor for changes on the `update-status` hook instead, which ensures that the credentials will at least be updated eventually (typically within 5 minutes).
3. Given that the update-status hook only runs every 5 minutes, we provide an optional `refresh-credentials` action to force an immediate refresh of the credentials.